### PR TITLE
add Date.toRFC3339

### DIFF
--- a/src/Exts/Date.elm
+++ b/src/Exts/Date.elm
@@ -1,8 +1,10 @@
-module Exts.Date exposing (toISOString)
+module Exts.Date exposing (toISOString, monthNumber, toRFC3339)
 
 {-| Extensions to the core `Date` library.
 
 @docs toISOString
+@docs toRFC3339
+@docs monthNumber
 -}
 
 import Date exposing (..)
@@ -29,6 +31,23 @@ toISOString d =
         ++ "Z"
 
 
+{-| Format a Date as an RFC-3339 standard string
+
+  This is useful for passing a Date as a value to an html input
+  see [the documentation](https://www.w3.org/TR/html-markup/input.date.html#input.date.attrs.value)
+  for more informations
+-}
+toRFC3339 : Date -> String
+toRFC3339 date =
+    (toString <| Date.year date)
+        ++ "-"
+        ++ (String.padLeft 2 '0' <| toString <| monthNumber date)
+        ++ "-"
+        ++ (String.padLeft 2 '0' <| toString <| Date.day date)
+
+
+{-| Extract the month of a given date as an integer. January is 1
+-}
 monthNumber : Date -> Int
 monthNumber date =
     case month date of

--- a/test/Tests/Exts/Date.elm
+++ b/test/Tests/Exts/Date.elm
@@ -7,7 +7,7 @@ import Date exposing (..)
 
 tests : Test
 tests =
-    suite "Exts.Date" [ toISOStringTests ]
+    suite "Exts.Date" [ toISOStringTests, toRFC3339Tests ]
 
 
 toISOStringTests : Test
@@ -20,5 +20,15 @@ toISOStringTests =
         , defaultTest
             (assertEqual (Ok "2015-10-21T00:00:00.000Z")
                 (Result.map toISOString (Date.fromString "Wed Oct 21 2015 01:00:00"))
+            )
+        ]
+
+
+toRFC3339Tests : Test
+toRFC3339Tests =
+    ElmTest.suite "toRFC3339"
+        [ defaultTest
+            (assertEqual (Ok "2015-10-20")
+                (Result.map toRFC3339 (Date.fromString "Tue Oct 20 2015 17:01:01"))
             )
         ]


### PR DESCRIPTION
I wanted to pass a date to an html input and went into this issue: http://stackoverflow.com/questions/14212527/how-to-set-default-value-to-the-inputtype-date 

Then I started to implement an helper to convert a Date into the RFC 3339 standard and I think your library is a good fit :)

I also exposed the function `monthNumber` as it was the first function I implemented for `toRFC3339` and I think it may be helpful for other use.
