### PR TITLE
Use unicode nbsp instead of empty string

### DIFF
--- a/src/Exts/Html.elm
+++ b/src/Exts/Html.elm
@@ -80,4 +80,4 @@ like `text "&nbsp"`, so use this string instead.
 -}
 nbsp : String
 nbsp =
-    " "
+    "\x00A0"


### PR DESCRIPTION
The empty string in nbsp is not the "non-breaking".

Easiest way is to use the unicode code point instead: `"\x00A0"`
(`&nbsp;` is just shorthand for that)
except `"\x00A0"` is a plaintext non-breaking space, so you don't have to be parsing something as HTML to use it 
