### PR TITLE
Avoid non-tail-recursive definition of catMaybes

### DIFF
--- a/src/Exts/Maybe.elm
+++ b/src/Exts/Maybe.elm
@@ -61,16 +61,8 @@ mappend a b =
 {-| Extract all the `Just` values from a List of Maybes.
 -}
 catMaybes : List (Maybe a) -> List a
-catMaybes xs =
-    case xs of
-        [] ->
-            []
-
-        Nothing :: rest ->
-            catMaybes rest
-
-        (Just x) :: rest ->
-            x :: catMaybes rest
+catMaybes =
+    List.filterMap identity
 
 
 {-| Join together two `Maybe` values using the supplied function. If


### PR DESCRIPTION
Existing implementation did explicit recursion to build the new list.
This is not tail recursive and thus may blow the stack.

New implementation utilizes core's List.filterMap.

Beside from being much simpler it also builds on core's
Native.List.foldr, which uses a native for loop instead of recursion.