### PR TITLE
add toSigFigs for rounding floats to a given number of significant fi…

### DIFF
--- a/src/Exts/Float.elm
+++ b/src/Exts/Float.elm
@@ -3,6 +3,8 @@ module Exts.Float exposing (..)
 {-| Extensions to the core `Float` library.
 
 @docs roundTo
+
+@docs toSigFigs
 -}
 
 
@@ -19,3 +21,26 @@ roundTo places value =
             |> toFloat
         )
             / factor
+
+
+{-| Round a `Float` to a given number of significant figures
+-}
+toSigFigs : Int -> Float -> Float
+toSigFigs sigFigs x =
+    if x == 0 then
+        0
+    else
+        let
+            absX =
+                abs x
+
+            logX =
+                logBase 10 absX
+
+            floorLogX =
+                floor logX
+
+            roundPlaces =
+                -(floorLogX - (sigFigs - 1))
+        in
+            roundTo roundPlaces x

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -6,6 +6,7 @@ import Tests.Exts.Basics
 import Tests.Exts.Date
 import Tests.Exts.Delta
 import Tests.Exts.Dict
+import Tests.Exts.Float
 import Tests.Exts.Int
 import Tests.Exts.Json.Decode
 import Tests.Exts.List
@@ -24,6 +25,7 @@ tests =
         , Tests.Exts.Date.tests
         , Tests.Exts.Delta.tests
         , Tests.Exts.Dict.tests
+        , Tests.Exts.Float.tests
         , Tests.Exts.Int.tests
         , Tests.Exts.Json.Decode.tests
         , Tests.Exts.List.tests

--- a/tests/Tests/Exts/Float.elm
+++ b/tests/Tests/Exts/Float.elm
@@ -1,0 +1,41 @@
+module Tests.Exts.Float exposing (tests)
+
+import Expect
+import Exts.Float exposing (..)
+import Test exposing (..)
+
+
+tests : Test
+tests =
+    describe "test sig figs function" <|
+        let
+            testPairs =
+                [ ( 3, 1111.1, 1110.0 )
+                , ( 1, 0.02342, 0.02 )
+                , ( 2, 2.2704234, 2.3 )
+                , ( 2, 20000, 20000 )
+                , ( 2, 201, 200 )
+                , ( 4, 0, 0 )
+                , ( 3, -12312.453, -12300 )
+                ]
+
+            expected =
+                List.map
+                    (\( sigFigs, val, expected ) ->
+                        expected
+                    )
+                    testPairs
+
+            funcResults =
+                List.map
+                    (\( sigFigs, val, expected ) ->
+                        toSigFigs sigFigs val
+                    )
+                    testPairs
+        in
+            [ test "results match expected" <|
+                \() ->
+                    Expect.equal
+                        expected
+                        funcResults
+            ]


### PR DESCRIPTION
…gures

This is different from `roundTo`. It's useful in instances where you want to control the level of precision of a float.